### PR TITLE
Fix term interface

### DIFF
--- a/src/YaoEGraph.jl
+++ b/src/YaoEGraph.jl
@@ -10,13 +10,30 @@ using Metatheory.TermInterface
 
 TermInterface.gethead(t::Chain) = :call
 TermInterface.getargs(t::Chain) = [:chain, t.args...]
+TermInterface.arity(t::Chain) = length(TermInterface.getargs(t))
+TermInterface.istree(e::Chain) = true
+
 TermInterface.gethead(t::Gate) = :call
 TermInterface.getargs(t::Gate) = [:gate, t.locations]
+TermInterface.arity(t::Gate) = length(TermInterface.getargs(t))
+TermInterface.istree(e::Gate) = true
+
 TermInterface.gethead(t::Ctrl) = :call
 TermInterface.getargs(t::Ctrl) = [:ctrl, t.gate, t.ctrl]
+TermInterface.arity(t::Ctrl) = length(TermInterface.getargs(t))
+TermInterface.istree(e::Ctrl) = true
 
-function EGraphs.extractnode(::EGraph, n::ENode{Chain}, extractor::Function)
+
+function EGraphs.extractnode(g::EGraph, n::ENode{T}, extractor::Function)
     return Chain(extractor.(n.args[2:end])...)
 end
+
+# function EGraphs.extractnode(g::EGraph, n::ENode{Gate}, extractor::Function)
+#     return Gate(extractor.(n.args[2:end])...)
+# end
+
+# function EGraphs.extractnode(g::EGraph, n::ENode{Ctrl}, extractor::Function)
+#     return Ctrl(extractor.(n.args[2:end])...)
+# end
 
 end

--- a/src/YaoEGraph.jl
+++ b/src/YaoEGraph.jl
@@ -24,7 +24,7 @@ TermInterface.arity(t::Ctrl) = length(TermInterface.getargs(t))
 TermInterface.istree(e::Ctrl) = true
 
 
-function EGraphs.extractnode(g::EGraph, n::ENode{T}, extractor::Function)
+function EGraphs.extractnode(g::EGraph, n::ENode{Chain}, extractor::Function)
     return Chain(extractor.(n.args[2:end])...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,13 +6,20 @@ using YaoHIR
 using YaoLocations
 using YaoHIR: X
 
-@metatheory_init
+@metatheory_init ()
 
 naive = @theory begin
     Chain(Gate(X, locs), Gate(X, locs)) |> Chain([])
 end
 
 circ = Chain(Gate(X, Locations(1)), Gate(X, Locations(1)))
+
+
+TermInterface.getargs(circ)
+
 egraph = EGraph(circ)
+
+display(egraph.classes); println()
+
 saturate!(egraph, naive)
 extract!(egraph, astsize)


### PR DESCRIPTION
Extraction was wrong because `istree` method was missing for `Chain` `Gate` and `Ctrl`